### PR TITLE
fix(build): don't mkdir network-keys dir

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,7 +30,7 @@ RUN apk update &&\
     libc6-compat
 
 # Create necessary directories
-RUN mkdir -p /val-data /rpc-data /usr/share/devnet-resources /val-data/consensus/beacondata/network-keys
+RUN mkdir -p /val-data /rpc-data /usr/share/devnet-resources /val-data/consensus/beacondata
 
 # Copy built binaries and scripts from build
 COPY --from=build /go-ethereum/bootnode /usr/bin/


### PR DESCRIPTION
prysm beacon client expects network keys to be in a `/val-data/consensus/beacon/network-keys` file instead of a file in that directory.